### PR TITLE
feat: make only inactive => active be syncable

### DIFF
--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -34,7 +34,7 @@ pub struct MeshState {
 
     /// Participants that are currently out-of-sync, they will become active
     /// once we finished synchronization.
-    pub need_sync: Vec<Participant>,
+    pub need_sync: Participants,
 
     /// Participants that can be selected for a new protocol invocation.
     pub stable: Vec<Participant>,
@@ -86,8 +86,8 @@ impl Mesh {
                     self.connections.report_node_synced(participant).await;
                     let mut state = self.state.write().await;
 
-                    if let Some(pos) = state.need_sync.iter().position(|p| *p == participant) {
-                        state.need_sync.remove(pos);
+                    if let Some(info) = state.need_sync.remove(&participant) {
+                        state.active.insert(&participant, info);
                         state.stable.push(participant);
                     }
                 }

--- a/chain-signatures/node/src/protocol/sync/mod.rs
+++ b/chain-signatures/node/src/protocol/sync/mod.rs
@@ -115,17 +115,10 @@ impl SyncTask {
 
                     let update = self.new_update(me).await;
                     let start = Instant::now();
-                    let receivers: Vec<(Participant, ParticipantInfo)> = need_sync
+                    let receivers = need_sync
                         .iter()
-                        .map(|p| {
-                            let info = state
-                                .active
-                                .participants
-                                .get(p)
-                                .expect("active set must contain all need_sync participants");
-                            (*p, info.clone())
-                        })
-                        .collect();
+                        .map(|(p, info)|(*p, info.clone()))
+                        .collect::<Vec<_>>();
                     let task = tokio::spawn(broadcast_sync(
                         self.client.clone(),
                         update,


### PR DESCRIPTION
Resharing shouldn't be a part of active either. This is so that we don't need to a sync when going from running to resharing

After this is merged, https://github.com/sig-net/mpc/pull/319 will be ready to go